### PR TITLE
Removed the archive switch from the cp action on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ FROM alpine:3.6
 RUN mkdir /plugins
 ADD ark-* /plugins/
 USER nobody:nobody
-ENTRYPOINT ["/bin/ash", "-c", "cp -a /plugins/* /target/."]
+ENTRYPOINT ["/bin/ash", "-c", "cp /plugins/* /target/."]


### PR DESCRIPTION
Hello, 

Really simple but stops the perms from the binary being copied in and allows it to run as nobody (I think). Works for me!

james