### PR TITLE
Example blockstore plugin

### DIFF
--- a/ark-blockstore-example/README.md
+++ b/ark-blockstore-example/README.md
@@ -1,0 +1,72 @@
+# Example blockstore plugin
+
+This directory contains source code for an ark blockstore plugin, it implements a no-op
+plugin ([this API](https://github.com/heptio/ark/blob/283a1349bdec670a1be0f3bfa19b07550c05b88f/pkg/cloudprovider/storage_interfaces.go#L62)).
+
+**It works only for hostpath PersistentVolumes**. Using it with other PersistentVolume types can have
+undefined behavior.
+
+## Prerequisites
+### To build
+- Docker
+
+### To run/test
+- A Kubernetes cluster
+- Ark (look [here](https://github.com/heptio/ark/blob/master/docs/quickstart.md) for install instructions)
+
+
+## Building this plugin
+
+1. Check out the sources
+  ```bash
+  git clone https://github.com/heptio/ark-plugin-example.git
+  ```
+
+2. Build the plugin Docker image
+  ```bash
+  make container
+  ```
+You should now have a Docker image named  `gcr.io/heptio-images/ark-plugin-example:latest`  
+Push it to a Docker registry that your Kubernetes cluster can pull from.
+
+# Deployment
+### Installation
+```bash
+   ark plugin add gcr.io/heptio-images/ark-plugin-example:latest
+```
+
+### Configuration
+1. ```bash
+      kubectl edit config -n heptio-ark
+   ```
+2. Set up "example" as the persistentVolumeProvider by adding the following snippet to the config spec:
+   ```yaml
+   persistentVolumeProvider:
+      name: example
+   ```
+   
+# Testing the plugin
+1. Install Test Application  
+   Now install an nginx-application with a pv like this :
+   ```bash
+   kubectl create -f ark-blockstore-example/pv.yaml
+   kubectl create -f ark-blockstore-example/pvc.yaml
+   kubectl create -f ark-blockstore-example/with-pv.yaml
+   ```
+
+2. Run a backup  
+   ```bash
+   ark backup create nginx-backup --selector app=nginx
+   ```
+
+3. Check backup status  
+   ```bash
+   ark backup get
+   ```
+
+4. Delete backup  
+  ```bash
+  ark backup delete nginx-backup
+  ```
+
+

--- a/ark-blockstore-example/main.go
+++ b/ark-blockstore-example/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/heptio/ark/pkg/plugin"
+)
+
+func main() {
+	plugin.Serve(plugin.NewBlockStorePlugin(NewNoOpBlockStore()))
+}

--- a/ark-blockstore-example/noop-plugin.go
+++ b/ark-blockstore-example/noop-plugin.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"errors"
+	"github.com/heptio/ark/pkg/cloudprovider"
+	"github.com/heptio/ark/pkg/plugin"
+	"github.com/heptio/ark/pkg/util/collections"
+	"github.com/sirupsen/logrus"
+	"math/rand"
+	"strconv"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Volume keeps track of volumes created by this plugin
+type Volume struct {
+	volType, az string
+	iops        int64
+}
+
+// Snapshot keeps track of snapshots created by this plugin
+type Snapshot struct {
+	volID, az string
+	tags         map[string]string
+}
+
+// Plugin for containing state for the blockstore plugin
+type NoOpBlockStore struct {
+	config    map[string]string
+	logrus.FieldLogger
+	volumes   map[string]Volume
+	snapshots map[string]Snapshot
+}
+
+var _ cloudprovider.BlockStore = (*NoOpBlockStore)(nil)
+
+func NewNoOpBlockStore() *NoOpBlockStore {
+	return &NoOpBlockStore{FieldLogger: plugin.NewLogger()}
+}
+
+// Init the plugin
+func (p *NoOpBlockStore) Init(config map[string]string) error {
+	p.Infof("Init called", config)
+	p.config = config
+
+	// Make this plugin re'initializable
+	p.volumes = make(map[string]Volume)
+	p.snapshots = make(map[string]Snapshot)
+	return nil
+}
+
+// CreateVolumeFromSnapshot Create a volume form given snapshot
+func (p *NoOpBlockStore) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (string, error) {
+	p.Infof("CreateVolumeFromSnapshot called", snapshotID, volumeType, volumeAZ, *iops)
+	var volumeID string
+	for {
+		volumeID := snapshotID + ".vol." + strconv.FormatUint(rand.Uint64(), 10)
+		if _, ok := p.volumes[volumeID]; ok {
+			// Duplicate ? Retry
+			continue
+		}
+		break
+	}
+
+	p.volumes[volumeID] = Volume{
+		volType: volumeType,
+		az:      volumeAZ,
+		// TODO: See https://github.com/heptio/ark/issues/814
+		iops: *iops,
+	}
+	return volumeID, nil
+}
+
+// GetVolumeInfo Get information about the volume
+func (p *NoOpBlockStore) GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error) {
+	p.Infof("GetVolumeInfo called", volumeID, volumeAZ)
+	if val, ok := p.volumes[volumeID]; ok {
+		// TODO: See https://github.com/heptio/ark/issues/814
+		iops := val.iops
+		return val.volType, &iops, nil
+	}
+	return "", nil, errors.New("Volume " + volumeID + " not found")
+}
+
+// IsVolumeReady Check if the volume is ready
+func (p *NoOpBlockStore) IsVolumeReady(volumeID, volumeAZ string) (ready bool, err error) {
+	p.Infof("IsVolumeReady called", volumeID, volumeAZ)
+	return true, nil
+}
+
+// CreateSnapshot Create a snapshot
+func (p *NoOpBlockStore) CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (string, error) {
+	p.Infof("CreateSnapshot called", volumeID, volumeAZ, tags)
+	var snapshotID string
+	for {
+		snapshotID = volumeID + ".snap." + strconv.FormatUint(rand.Uint64(), 10)
+		p.Infof("CreateSnapshot trying to create snapshot", snapshotID)
+		if _, ok := p.snapshots[snapshotID]; ok {
+			// Duplicate ? Retry
+			continue
+		}
+		break
+	}
+
+	// Remember the "original" volume, only required for the first
+	// time.
+	if _, exists := p.volumes[volumeID]; !exists {
+		p.volumes[volumeID] = Volume{
+			volType: "orignalVolumeType",
+			az:      volumeAZ,
+			iops: 100,
+		}
+	}
+
+	// Remember the snapshot
+	p.snapshots[snapshotID] = Snapshot{volID: volumeID,
+			az:   volumeAZ,
+			tags: tags}
+
+
+	p.Infof("CreateSnapshot returning", snapshotID)
+	return snapshotID, nil
+}
+
+// DeleteSnapshot Delete a snapshot
+func (p *NoOpBlockStore) DeleteSnapshot(snapshotID string) error {
+	p.Infof("DeleteSnapshot called", snapshotID)
+	delete(p.snapshots, snapshotID)
+	return nil
+}
+
+// GetVolumeID Get the volume ID from the spec
+func (p *NoOpBlockStore) GetVolumeID(pv runtime.Unstructured) (string, error) {
+	p.Infof("GetVolumeID called", pv)
+	if !collections.Exists(pv.UnstructuredContent(), "spec.hostPath.path") {
+		return "", errors.New("Example plugin failed to get volume ID. ")
+	}
+
+	return collections.GetString(pv.UnstructuredContent(), "spec.hostPath.path")
+}
+
+// SetVolumeID Set the volume ID in the spec
+func (p *NoOpBlockStore) SetVolumeID(pv runtime.Unstructured, volumeID string) (runtime.Unstructured, error) {
+	p.Infof("SetVolumeID called", pv, volumeID)
+	metadataMap, err := collections.GetMap(pv.UnstructuredContent(), "spec.hostPath.path")
+	if err != nil {
+		return nil, err
+	}
+
+	metadataMap["volumeID"] = volumeID
+	return pv, nil
+}

--- a/ark-blockstore-example/pv.yaml
+++ b/ark-blockstore-example/pv.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: mypv
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp"

--- a/ark-blockstore-example/pvc.yaml
+++ b/ark-blockstore-example/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mypvc
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi

--- a/ark-blockstore-example/with-pv.yaml
+++ b/ark-blockstore-example/with-pv.yaml
@@ -1,0 +1,64 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-example
+  labels:
+    app: nginx
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: nginx-example
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      volumes:
+        - name: nginx-logs
+          persistentVolumeClaim:
+           claimName: mypvc
+      containers:
+      - image: nginx:1.7.9
+        name: nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - mountPath: "/var/log/nginx"
+            name: nginx-logs
+            readOnly: false
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: my-nginx
+  namespace: nginx-example
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+  type: LoadBalancer


### PR DESCRIPTION
Add an example for a blockstore.

    Add in a no-op blockstore plugin.
    The implementation tries to remember snapshots/volumes created by
    storing it in an internal map. This allows us to do basic validation.

    No interaction with the Kubernetes objects is actually done, and of
    course, no real storage operations happen.

This should fix https://github.com/heptio/ark-plugin-example/issues/3 