### PR TITLE
switch to debian:stretch-slim base image, update to go 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 the Heptio Ark contributors.
+# Copyright 2017, 2019 the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM debian:stretch-slim
 RUN mkdir /plugins
 ADD velero-* /plugins/
 USER nobody:nobody
-ENTRYPOINT ["/bin/ash", "-c", "cp /plugins/* /target/."]
+ENTRYPOINT ["/bin/bash", "-c", "cp /plugins/* /target/."]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 the Heptio Ark contributors.
+# Copyright 2017, 2019 the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ BIN ?= $(wildcard velero-*)
 # This repo's root import path (under GOPATH).
 PKG := github.com/heptio/velero-plugin-example
 
-BUILD_IMAGE ?= golang:1.11-alpine3.8
+BUILD_IMAGE ?= golang:1.12-stretch
 
 IMAGE ?= gcr.io/heptio-images/velero-plugin-example
 
@@ -71,6 +71,7 @@ shell: build-dirs
 		-v $$(pwd)/.go/std:/go/std \
 		-v $$(pwd):/go/src/$(PKG) \
 		-v $$(pwd)/.go/std/$(GOOS)_$(GOARCH):/usr/local/go/pkg/$(GOOS)_$(GOARCH)_static \
+		-v "$$(pwd)/.go/go-build:/.cache/go-build:delegated" \
 		-e CGO_ENABLED=0 \
 		-w /go/src/$(PKG) \
 		$(BUILD_IMAGE) \


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>