### PR TITLE
migrate to GitHub Actions for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+on: [pull_request, push]
+jobs:
+  build:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v2
+    - name: Run make ci
+      run: make ci
+  build-container:
+    name: Build container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+      - name: Run make container
+        run: VERSION=ci-build make container

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: go
-
-go:
-  - 1.14.x
-
-script: make ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.14-buster AS build
 ENV GOPROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/vmware-tanzu/velero-plugin-example
 COPY . .
-RUN CGO_ENABLED=0 go build -v -o /go/bin/velero-plugin-example .
+RUN CGO_ENABLED=0 go build -o /go/bin/velero-plugin-example .
 
 
 FROM ubuntu:bionic

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 
 # ci is a convenience target for CI builds.
 .PHONY: ci
-ci: verify-modules local test container
+ci: verify-modules local test
 
 # container builds a Docker image containing the binary.
 .PHONY: container

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Velero Example Plugins
 
-[![Build Status][1]][2]
+![Build Status][1]
 
 This repository contains example plugins for Velero.
 
@@ -106,5 +106,5 @@ If you need to pull in additional dependencies to your vendor directory, just ru
 $ dep ensure
 ```
 
-[1]: https://travis-ci.org/vmware-tanzu/velero-plugin-example.svg?branch=master
-[2]: https://travis-ci.org/vmware-tanzu/velero-plugin-example
+[1]: https://github.com/vmware-tanzu/velero-plugin-example/workflows/Continuous%20Integration/badge.svg
+


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Replace Travis with GitHub Actions, run `go build/go test` in one job and `make container` in another parallel job.  Looks good on my fork, see https://github.com/skriss/velero-plugin-example/actions/runs/74757194.

Maybe the last PR for now for this repo!