### PR TITLE
Update AppliesTo comments to show resources with group names work

### DIFF
--- a/internal/plugin/backupplugin.go
+++ b/internal/plugin/backupplugin.go
@@ -37,6 +37,8 @@ func NewBackupPlugin(log logrus.FieldLogger) *BackupPlugin {
 }
 
 // AppliesTo returns information about which resources this action should be invoked for.
+// The IncludedResources and ExcludedResources slices can include both resources
+// and resources with group names. These work: "ingresses", "ingresses.extensions".
 // A BackupPlugin's Execute function will only be invoked on items that match the returned
 // selector. A zero-valued ResourceSelector matches all resources.
 func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {

--- a/internal/plugin/restoreplugin.go
+++ b/internal/plugin/restoreplugin.go
@@ -33,6 +33,8 @@ func NewRestorePlugin(log logrus.FieldLogger) *RestorePlugin {
 }
 
 // AppliesTo returns information about which resources this action should be invoked for.
+// The IncludedResources and ExcludedResources slices can include both resources
+// and resources with group names. These work: "ingresses", "ingresses.extensions".
 // A RestoreItemAction's Execute function will only be invoked on items that match the returned
 // selector. A zero-valued ResourceSelector matches all resources.g
 func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {


### PR DESCRIPTION
Fixes the issue reported in the vmware-tanzu/velero repository [Issue 3491](https://github.com/vmware-tanzu/velero/issues/3491).

The issue was it wasn't clear from the naming of "ResourceSelector", "ResourcesIncluded", and "ResourcesExcluded" that we could use group names with the resource names. Not specifying the group name caused us issues when we tried to make a plugin for ingresses which is in both the extensions and networking.k8s.io groups. Hopefully, by making it more clear in the comments other will not struggle with the same issue we had.

Signed-off-by: F. Gold <fgold@vmware.com>