### PR TITLE
update busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /go/src/github.com/vmware-tanzu/velero-plugin-example
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/velero-plugin-example .
 
-FROM busybox:1.33.1 AS busybox
+FROM busybox:1.37.0-musl AS busybox
 
 FROM scratch
 COPY --from=build /go/bin/velero-plugin-example /plugins/


### PR DESCRIPTION
## What

Update busybox image 

In older versions of the busybox Docker image, the binaries were compiled statically. This meant that all the code required to run the program was baked directly into the single executable.

To solve this, you need to use a version of BusyBox that is statically linked, meaning it brings no outside dependencies with it, thus using -musl